### PR TITLE
ISSUE-32: restore CDN libraries but bump to 4.5.2 and fix missing min-width

### DIFF
--- a/archipelago_subtheme.libraries.yml
+++ b/archipelago_subtheme.libraries.yml
@@ -15,6 +15,13 @@ bootstrap:
   css:
     component:
       /libraries/bootstrap/dist/css/bootstrap.min.css: {}
+bootstrap_cdn:
+  js:
+    //cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js: {}
+    //stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js: {}
+  css:
+    component:
+      //stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css: {}
 color.preview:
   version: VERSION
   css:
@@ -26,12 +33,12 @@ color.preview:
     - color/drupal.color
 fonts:
   css:
-    theme:
-      '//fonts.googleapis.com/css?family=Mukta:400,500,600,700': { type: external, minified: true }
+    theme:   
+      //fonts.googleapis.com/css2?family=Mukta:wght@400;500;600;700&display=swap: {type: external, minified: false }
 
 robot_cabin:
   version: VERSION
   css:
     component:
-      fonts/robot_cabin.css: {}
-      //fonts.googleapis.com/css?family=Cabin|Roboto:400,700|Roboto+Condensed:400,700: {}
+      fonts/robot_cabin.css: {}  
+      //fonts.googleapis.com/css2?family=Cabin:wght@300;400;700&family=Roboto:wght@300;400;700&family=Roboto+Condensed:wght@300;400;700&display=swap: {type: external, minified: false}

--- a/css/custom.css
+++ b/css/custom.css
@@ -19,6 +19,11 @@ body.path-frontpage {
     display: none;
 }
 
+/* Fixes Bootstrap 4.5.1 removing this for .col*/
+/* Making JS innerWidth() unexpectedly super width (scree width) when resizing a Canvas */
+#content.col {
+  min-width:0;
+}
 
 .content {
     padding-bottom: 2rem;
@@ -584,4 +589,14 @@ div#sidebar_second.sidebar.col-md-3.order-last:empty {
     width:3em;
     height:3em;
     background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 129 129" xmlns:xlink="http://www.w3.org/1999/xlink"><path stroke="black" stroke-width="2" stroke-linecap="round" d="m40.4,121.3c-0.8,0.8-1.8,1.2-2.9,1.2s-2.1-0.4-2.9-1.2c-1.6-1.6-1.6-4.2 0-5.8l51-51-51-51c-1.6-1.6-1.6-4.2 0-5.8 1.6-1.6 4.2-1.6 5.8,0l53.9,53.9c1.6,1.6 1.6,4.2 0,5.8l-53.9,53.9z"></path></svg>');
+}
+
+/* remove padding for Views element content */
+main.main-content .views-element-container div.content {
+  padding: 0 0 0 0
+}
+
+/* Add spacing to pager in a views */
+ul.pagination {
+ padding-top:1.5em;
 }


### PR DESCRIPTION
See #32 

- Also updates Font Links to css2
- Restores CDN libraries (why did I even remove those?)
- Fixes broken JS calculate-able .col with (for dynamic sizing canvases == 3D)
@aksm @alliomeria @karomabiles  (FYIL the funny looking 3D dish)